### PR TITLE
Added css style hex colors feature Features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple library to do some basic terminal stuff.
 const termctl = require("termctl");
 ```
 
-**Note:** I have tested this just on my Linux Mint so I don't know if changing colors will work on Mac.
+**Note:** I have tested this just on my Linux Mint and Windows but I don't know if changing colors will work on Mac.
 
 # Methods
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Just using escape sequences inside these methods for changing styles.
   // termctl.color.set_bg(r: number, g: number, b: number): void
 
   termctl.color.set_bg(255, 255, 100);
+  // (or) css style hex colors
+  termctl.color.set_fg(0xFFFF64); // 0xRRGGBB format
   ```
 
 - Reset background color to default
@@ -60,6 +62,8 @@ Just using escape sequences inside these methods for changing styles.
   // termctl.color.set_bg(r: number, g: number, b: number): void
 
   termctl.color.set_fg(0, 0, 0);
+  // (or) css style hex colors
+  termctl.color.set_fg(0x000000); // 0xRRGGBB format
   ```
 
 - Reset foreground color to default

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple library to do some basic terminal stuff.
 const termctl = require("termctl");
 ```
 
-**Note:** I have tested this just on my Linux Mint so I don't know if changing colors will work on Windows or Mac.
+**Note:** I have tested this just on my Linux Mint so I don't know if changing colors will work on Mac.
 
 # Methods
 
@@ -39,9 +39,8 @@ const termctl = require("termctl");
   ```
 
 ## Styling
-Just using escape sequences inside these methods for changing styles.
 
-- Set background color
+- Sets background color
   ```javascript
   // termctl.color.set_bg(r: number, g: number, b: number): void
 
@@ -50,14 +49,14 @@ Just using escape sequences inside these methods for changing styles.
   termctl.color.set_bg(0xFFFF64); // 0xRRGGBB format
   ```
 
-- Reset background color to default
+- Resets background color to default
   ```javascript
   // termctl.color.reset_bg(): void
 
   termctl.color.reset_bg();
   ```
 
-- Set foreground color
+- Sets foreground color
   ```javascript
   // termctl.color.set_bg(r: number, g: number, b: number): void
 
@@ -94,11 +93,14 @@ Just using escape sequences inside these methods for changing styles.
   termctl.color.set_underline();
   ```
 
-- Reset all styles to default
+- Resets all styles to default
   ```javascript
   // termctl.color.reset_styles(): void
 
   termctl.color.reset_styles();
   ```
 
-> Read _tests/test.js_ to see termctl in action.
+> <b>Note:</b> We are just using escape sequences inside these methods for changing styles. So resetting styles before exiting is always good idea.
+
+
+> Test scripts goes inside _tests/test.js_ You can also use it as reference (i.e) Examples.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple library to do some basic terminal stuff.
 const termctl = require("termctl");
 ```
 
-**Note:** I have tested this just on my Linux Mint and Windows but I don't know if changing colors will work on Mac.
+**Note:** We have tested this on Linux Mint and Windows 10 but we don't know if changing colors will work on Mac.
 
 # Methods
 
@@ -40,27 +40,29 @@ const termctl = require("termctl");
 
 ## Styling
 
-- Sets background color
+- Set background color
   ```javascript
   // termctl.color.set_bg(r: number, g: number, b: number): void
 
   termctl.color.set_bg(255, 255, 100);
+
   // (or) css style hex colors
   termctl.color.set_bg(0xFFFF64); // 0xRRGGBB format
   ```
 
-- Resets background color to default
+- Reset background color to default
   ```javascript
   // termctl.color.reset_bg(): void
 
   termctl.color.reset_bg();
   ```
 
-- Sets foreground color
+- Set foreground color
   ```javascript
   // termctl.color.set_bg(r: number, g: number, b: number): void
 
   termctl.color.set_fg(0, 0, 0);
+
   // (or) css style hex colors
   termctl.color.set_fg(0x000000); // 0xRRGGBB format
   ```
@@ -100,7 +102,4 @@ const termctl = require("termctl");
   termctl.color.reset_styles();
   ```
 
-> <b>Note:</b> We are just using escape sequences inside these methods for changing styles. So resetting styles before exiting is always good idea.
-
-
-> Test scripts goes inside _tests/test.js_ You can also use it as reference (i.e) Examples.
+> **Note:** We are just using escape sequences inside these methods for changing styles. So resetting styles before exiting is always a good idea.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Just using escape sequences inside these methods for changing styles.
 
   termctl.color.set_bg(255, 255, 100);
   // (or) css style hex colors
-  termctl.color.set_fg(0xFFFF64); // 0xRRGGBB format
+  termctl.color.set_bg(0xFFFF64); // 0xRRGGBB format
   ```
 
 - Reset background color to default

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
         if (rl == null)
             throw new Error("Call init() once to use gets()");
 
-        rl.output = echo ? stdout: null;
+        rl.output = echo ? stdout : null;
 
         if (!echo)
             stdout.write(query);
@@ -45,6 +45,10 @@ module.exports = {
     /***  Styles  ***/
     color: {
         set_bg(r, g, b) {
+            if (g === undefined && b === undefined) {
+                stdout.write(`\x1b[48;2;${(r & 0xFF0000) >> 16 };${(r & 0x00FF00) >> 8};${ r & 0x0000FF}m`);
+                return;
+            }
             stdout.write(`\x1b[48;2;${r};${g};${b}m`);
         },
 
@@ -53,6 +57,10 @@ module.exports = {
         },
 
         set_fg(r, g, b) {
+            if (g === undefined && b === undefined) {
+                stdout.write(`\x1b[38;2;${(r & 0xFF0000) >> 16 };${(r & 0x00FF00) >> 8};${ r & 0x0000FF}m`);
+                return;
+            }
             stdout.write(`\x1b[38;2;${r};${g};${b}m`);
         },
 

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = {
     },
 
     gets(query = '', echo = true) {
-        if (rl == null)
+        if (rl === null)
             throw new Error("Call init() once to use gets()");
 
         rl.output = echo ? stdout : null;
@@ -49,6 +49,7 @@ module.exports = {
                 stdout.write(`\x1b[48;2;${(r & 0xFF0000) >> 16 };${(r & 0x00FF00) >> 8};${ r & 0x0000FF}m`);
                 return;
             }
+
             stdout.write(`\x1b[48;2;${r};${g};${b}m`);
         },
 
@@ -61,6 +62,7 @@ module.exports = {
                 stdout.write(`\x1b[38;2;${(r & 0xFF0000) >> 16 };${(r & 0x00FF00) >> 8};${ r & 0x0000FF}m`);
                 return;
             }
+
             stdout.write(`\x1b[38;2;${r};${g};${b}m`);
         },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "termctl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A simple library to do some basic terminal stuff.",
   "main": "index.js",
   "scripts": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -17,6 +17,12 @@ const termctl = require("../index.js");
 
         // validation...
 
+
+        // colors from https://www.materialpalette.com/pink/red
+        termctl.color.set_bg(0xC2185B); // Dark Primary Color
+        termctl.color.set_fg(0xFFFFFF); // Text / Icon
+        
+
         termctl.set_italic();
         console.log("\nLogin successful...");
     } catch(err) {


### PR DESCRIPTION
Now you can also do like.
```javascript 
termctl.color.set_fg(0xFFFF64); // 0xRRGGBB format
 ``` 
to set foreground and same goes for background color.

- Corrected Readme.md [#627fab5](https://github.com/biraj21/termctl/pull/1/commits/627fab5c12171b43f933b239b86337b49ac8a471)
- Tested on Windows
![Screenshot (100)](https://user-images.githubusercontent.com/31966594/135023570-afcc9ef8-e0e4-4e8a-92cb-f9ad4882a2a3.png)
 